### PR TITLE
Create issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+
+👋 Thanks for submitting a PR!
+A good pull request goes a long way. Before submitting this pull request, please make sure you can check the following boxes:
+- [ ] If this is a UI change, I have tested the change in mobile, tablet, and desktop viewports
+- [ ] I have performed a self-review of my own code
+- [ ] I have selected a title that summarizes my fix
+- [ ] My code follows the code style of this project.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+
+Next, fill out the following sections:
+
+-->
+
+## Description
+<!-- A description of the change and which issue or behavior is addressed.                      -->
+
+<!-- Is this a UI change? If so, include screenshots!                                           -->
+
+Fixes #<!-- Issue -->
+<!-- This project only accepts pull requests related to open issues. If an issue does not exist -->
+<!-- for this change, please check out our guide at CONTRIBUTING.md to create one.              -->
+
+## Motivation and Context
+<!-- Answering the question, "why is this change necessary?" or "what problem does it solve?"   -->
+
+## Type of change
+<!-- Delete any of the following that do not apply, and put an `x` where it does!               -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation change (updates to README and related files)


### PR DESCRIPTION
This adds [issue templates](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) and a [PR template](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository) to the Code for Boston GitHub Organization. These templates will be applied to all projects that do not have their own templates defined.

The issue templates are based almost completely on the [GitHub standard templates](https://help.github.com/en/articles/creating-issue-templates-for-your-repository), with only small tweaks to trim templates down to what works for most Code for Boston teams. This is part of an effort to create [default health files for Code for Boston's GitHub](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization).

See https://help.github.com/en/articles/about-issue-and-pull-request-templates for more information about issue/pull request templates.