### PR TITLE
Create default CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing Guide
+
+Thanks for your interest in contributing! These notes will hopefully get you situated.
+
+## Team Communication
+
+This team (and all [Code for Boston](https://www.codeforboston.org/) teams) communicates over slack. If you haven't already done so, you'll want to [create a Code for Boston Slack account](https://communityinviter.com/apps/cfb-public/code-for-boston-slack-invite). From there you can find team members and help coordinate around work.
+
+You can also attend any [Code for Boston Meetup](https://www.meetup.com/Code-for-Boston/) to get together in person.
+
+If you're interested in getting started but not sure how to dive in, one of those two ways of getting in touch with the team is probably the best way to get started.
+
+## Contributing Code
+
+Some of the best ways to find out where to jump in are to either talk to someone on the team (see above for team communication), or look for [issues](issues) marked as [low hanging fruit](contribute). For new contributors, we suggest that you first [fork the repository](https://help.github.com/en/articles/about-forks) in order to track your changes, then create a [pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). [See this guide for best practices regarding forking and creating a pull request](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+
+You can also get familiar with the codebase by [reviewing any outstanding pull requests](pulls) - check out [GitHub's course on pull request review best practices](https://lab.github.com/githubtraining/reviewing-pull-requests).
+
+Thanks again for contributing!
+
+---
+[Code of Conduct](https://www.codeforboston.org/code-of-conduct/) | [Code for Boston website](https://www.codeforboston.org/code-of-conduct/) | [Code for America Brigade network](https://brigade.codeforamerica.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ If you're interested in getting started but not sure how to dive in, one of thos
 
 ## Contributing Code
 
-Some of the best ways to find out where to jump in are to either talk to someone on the team (see above for team communication), or look for [issues](issues) marked as [low hanging fruit](contribute). For new contributors, we suggest that you first [fork the repository](https://help.github.com/en/articles/about-forks) in order to track your changes, then create a [pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). [See this guide for best practices regarding forking and creating a pull request](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+Some of the best ways to find out where to jump in are to either talk to someone on the team (see above for team communication), or look for [issues](../../issues) marked as [low hanging fruit](../../contribute). For new contributors, we suggest that you first [fork the repository](https://help.github.com/en/articles/about-forks) in order to track your changes, then create a [pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). [See this guide for best practices regarding forking and creating a pull request](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
-You can also get familiar with the codebase by [reviewing any outstanding pull requests](pulls) - check out [GitHub's course on pull request review best practices](https://lab.github.com/githubtraining/reviewing-pull-requests).
+You can also get familiar with the codebase by [reviewing any outstanding pull requests](../../pulls) - check out [GitHub's course on pull request review best practices](https://lab.github.com/githubtraining/reviewing-pull-requests).
 
 Thanks again for contributing!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ If you're interested in getting started but not sure how to dive in, one of thos
 
 ## Contributing Code
 
-Some of the best ways to find out where to jump in are to either talk to someone on the team (see above for team communication), or look for [issues](../../issues) marked as [low hanging fruit](../../contribute). For new contributors, we suggest that you first [fork the repository](https://help.github.com/en/articles/about-forks) in order to track your changes, then create a [pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). [See this guide for best practices regarding forking and creating a pull request](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+Some of the best ways to find out where to jump in are to either talk to someone on the team (see above for team communication), or look for Issues marked with labels such as `help wanted` or `good first issue`. For new contributors, we suggest that you first [fork the repository](https://help.github.com/en/articles/about-forks) in order to track your changes, then create a [pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). [See this guide for best practices regarding forking and creating a pull request](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
-You can also get familiar with the codebase by [reviewing any outstanding pull requests](../../pulls) - check out [GitHub's course on pull request review best practices](https://lab.github.com/githubtraining/reviewing-pull-requests).
+You can also get familiar with the codebase by reviewing any outstanding pull requests - check out [GitHub's course on pull request review best practices](https://lab.github.com/githubtraining/reviewing-pull-requests).
 
 Thanks again for contributing!
 


### PR DESCRIPTION
This adds [guidelines for contributors](https://help.github.com/en/articles/setting-guidelines-for-repository-contributors) to the Code for Boston GitHub Organization. This guide will be linked to for anyone creating a new PR or Issue on a repository that doesn't have their own template defined.

Image from GitHub's article above:
![image](https://user-images.githubusercontent.com/12058/62177551-4da63700-b313-11e9-9966-86b1082f85f3.png)
