### PR TITLE
Update FUNDING.yml (Closes Issue #4)

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-website&brigade=Code%20for%20Boston
+custom: https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=CodeforBoston&utm_source=github


### PR DESCRIPTION
-Fixes broken sponsorship links being applied to all Code For Boston projects on GitHub (Issue #4). 

-Adds utm_campagin and utm_source tags in the link URL for tracking in google analytics.